### PR TITLE
fix: apply suggestions from pre-commit hooks

### DIFF
--- a/superset/db_engine_specs/ocient.py
+++ b/superset/db_engine_specs/ocient.py
@@ -235,8 +235,8 @@ class OcientEngineSpec(BaseEngineSpec):
     @classmethod
     def get_table_names(
         cls, database: Database, inspector: Inspector, schema: Optional[str]
-    ) -> List[str]:
-        return sorted(inspector.get_table_names(schema))
+    ) -> Set[str]:
+        return inspector.get_table_names(schema)
 
     @classmethod
     def fetch_data(cls, cursor, lim=None):

--- a/superset/db_engine_specs/ocient.py
+++ b/superset/db_engine_specs/ocient.py
@@ -16,20 +16,19 @@
 # under the License.
 
 import re
-
-from sqlalchemy.engine.reflection import Inspector
-from sqlalchemy.orm import Session
-from superset.db_engine_specs.base import BaseEngineSpec
-from superset.errors import SupersetErrorType
-from flask_babel import gettext as __
+import threading
+from typing import Any, Callable, Dict, List, NamedTuple, Optional, Pattern, Tuple
 
 import pyocient
-from pyocient import _STPoint, _STLinestring, _STPolygon, TypeCodes
-from superset import app
-from superset.models.core import Database
-from typing import Any, Callable, Dict, List, NamedTuple, Tuple, Optional, Pattern
-import threading
+from flask_babel import gettext as __
+from pyocient import _STLinestring, _STPoint, _STPolygon, TypeCodes
+from sqlalchemy.engine.reflection import Inspector
+from sqlalchemy.orm import Session
 
+from superset import app
+from superset.db_engine_specs.base import BaseEngineSpec
+from superset.errors import SupersetErrorType
+from superset.models.core import Database
 from superset.models.sql_lab import Query
 
 # Ensure pyocient inherits Superset's logging level

--- a/superset/db_engine_specs/ocient.py
+++ b/superset/db_engine_specs/ocient.py
@@ -239,7 +239,9 @@ class OcientEngineSpec(BaseEngineSpec):
         return inspector.get_table_names(schema)
 
     @classmethod
-    def fetch_data(cls, cursor, lim=None):
+    def fetch_data(
+        cls, cursor: Any, lim: Optional[int] = None
+    ) -> List[Tuple[Any, ...]]:
         try:
             rows = super(OcientEngineSpec, cls).fetch_data(cursor)
         except Exception as exception:

--- a/tests/unit_tests/db_engine_specs/test_ocient.py
+++ b/tests/unit_tests/db_engine_specs/test_ocient.py
@@ -18,11 +18,11 @@
 # pylint: disable=import-outside-toplevel
 
 from datetime import datetime
+from typing import Dict, List, Tuple
 
 import pytest
 
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
-from typing import Dict, List, Tuple
 
 
 @pytest.mark.parametrize(
@@ -38,10 +38,11 @@ def test_convert_dttm(actual: str, expected: str, dttm: datetime) -> None:
 
     assert OcientEngineSpec.convert_dttm(actual, dttm) == expected
 
+
 # (msg,expected)
-MARSHALED_OCIENT_ERRORS: List[Tuple[str, Dict]] = [
+MARSHALED_OCIENT_ERRORS: List[Tuple[str, SupersetError]] = [
     (
-        'The referenced user does not exist (User \'mj\' not found)',
+        "The referenced user does not exist (User 'mj' not found)",
         SupersetError(
             message='The username "mj" does not exist.',
             error_type=SupersetErrorType.CONNECTION_INVALID_USERNAME_ERROR,
@@ -55,12 +56,12 @@ MARSHALED_OCIENT_ERRORS: List[Tuple[str, Dict]] = [
                     }
                 ],
             },
-        )
+        ),
     ),
     (
-        'The userid/password combination was not valid (Incorrect password for user)',
+        "The userid/password combination was not valid (Incorrect password for user)",
         SupersetError(
-            message='The user/password combination is not valid (Incorrect password for user).',
+            message="The user/password combination is not valid (Incorrect password for user).",
             error_type=SupersetErrorType.CONNECTION_INVALID_PASSWORD_ERROR,
             level=ErrorLevel.ERROR,
             extra={
@@ -72,10 +73,10 @@ MARSHALED_OCIENT_ERRORS: List[Tuple[str, Dict]] = [
                     }
                 ],
             },
-        )
+        ),
     ),
     (
-        'No database named \'bulls\' exists',
+        "No database named 'bulls' exists",
         SupersetError(
             message='Could not connect to database: "bulls"',
             error_type=SupersetErrorType.CONNECTION_UNKNOWN_DATABASE_ERROR,
@@ -89,10 +90,10 @@ MARSHALED_OCIENT_ERRORS: List[Tuple[str, Dict]] = [
                     }
                 ],
             },
-        )
+        ),
     ),
     (
-        'Unable to connect to unitedcenter.com:4050',
+        "Unable to connect to unitedcenter.com:4050",
         SupersetError(
             message='Could not resolve hostname: "unitedcenter.com".',
             error_type=SupersetErrorType.CONNECTION_INVALID_HOSTNAME_ERROR,
@@ -106,12 +107,12 @@ MARSHALED_OCIENT_ERRORS: List[Tuple[str, Dict]] = [
                     }
                 ],
             },
-        )
+        ),
     ),
     (
-        'Port out of range 0-65535',
+        "Port out of range 0-65535",
         SupersetError(
-            message='Port out of range 0-65535',
+            message="Port out of range 0-65535",
             error_type=SupersetErrorType.CONNECTION_INVALID_PORT_ERROR,
             level=ErrorLevel.ERROR,
             extra={
@@ -123,12 +124,12 @@ MARSHALED_OCIENT_ERRORS: List[Tuple[str, Dict]] = [
                     }
                 ],
             },
-        )
+        ),
     ),
     (
-        'An invalid connection string attribute was specified (failed to decrypt cipher text)',
+        "An invalid connection string attribute was specified (failed to decrypt cipher text)",
         SupersetError(
-            message='Invalid Connection String: Expecting String of the form \'ocient://user:pass@host:port/database\'.',
+            message="Invalid Connection String: Expecting String of the form 'ocient://user:pass@host:port/database'.",
             error_type=SupersetErrorType.GENERIC_DB_ENGINE_ERROR,
             level=ErrorLevel.ERROR,
             extra={
@@ -140,10 +141,10 @@ MARSHALED_OCIENT_ERRORS: List[Tuple[str, Dict]] = [
                     }
                 ],
             },
-        )
+        ),
     ),
     (
-        'There is a syntax error in your statement (extraneous input \'foo bar baz\' expecting ',
+        "There is a syntax error in your statement (extraneous input 'foo bar baz' expecting ",
         SupersetError(
             message='Extraneous input: "foo bar baz".',
             error_type=SupersetErrorType.SYNTAX_ERROR,
@@ -157,10 +158,10 @@ MARSHALED_OCIENT_ERRORS: List[Tuple[str, Dict]] = [
                     }
                 ],
             },
-        )
+        ),
     ),
     (
-        'There is a syntax error in your statement (mismatched input \'to\' expecting {<EOF>, \'trace\', \'using\'})',
+        "There is a syntax error in your statement (mismatched input 'to' expecting {<EOF>, 'trace', 'using'})",
         SupersetError(
             message='Extraneous input: "foo bar baz".',
             error_type=SupersetErrorType.SYNTAX_ERROR,
@@ -174,10 +175,10 @@ MARSHALED_OCIENT_ERRORS: List[Tuple[str, Dict]] = [
                     }
                 ],
             },
-        )
+        ),
     ),
     (
-        'The referenced table or view \'goats\' does not exist',
+        "The referenced table or view 'goats' does not exist",
         SupersetError(
             message='Table or View "goats" does not exist.',
             error_type=SupersetErrorType.TABLE_DOES_NOT_EXIST_ERROR,
@@ -192,13 +193,13 @@ MARSHALED_OCIENT_ERRORS: List[Tuple[str, Dict]] = [
                     {
                         "code": 1005,
                         "message": "Issue 1005 - The table was deleted or renamed in the database.",
-                    }
+                    },
                 ],
             },
-        )
+        ),
     ),
     (
-        'The reference to column \'goats\' is not valid',
+        "The reference to column 'goats' is not valid",
         SupersetError(
             message='Invalid reference to column: "goats"',
             error_type=SupersetErrorType.COLUMN_DOES_NOT_EXIST_ERROR,
@@ -213,21 +214,17 @@ MARSHALED_OCIENT_ERRORS: List[Tuple[str, Dict]] = [
                     {
                         "code": 1004,
                         "message": "Issue 1004 - The column was deleted or renamed in the database.",
-                    }
+                    },
                 ],
             },
-        )
+        ),
     ),
 ]
 
-@pytest.mark.parametrize(
-    "msg,expected",
-    MARSHALED_OCIENT_ERRORS
-)
+
+@pytest.mark.parametrize("msg,expected", MARSHALED_OCIENT_ERRORS)
 def test_connection_errors(msg: str, expected: SupersetError) -> None:
     from superset.db_engine_specs.ocient import OcientEngineSpec
 
     result = OcientEngineSpec.extract_errors(Exception(msg))
-    assert result == [
-        expected
-    ]
+    assert result == [expected]


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
```
(.venv) jwilliams@jwilliams-dev0:/ocient/db/superset (master)$ tox -e pre-commit
pre-commit installed: apache-superset==0.0.0.dev0,backports.entry-points-selectable==1.1.0,build==0.8.0,cfgv==3.3.0,click==8.0.4,distlib==0.3.2,filelock==3.0.12,identify==2.2.13,nodeenv==1.6.0,packaging==21.3,pep517==0.11.0,pip-compile-multi==2.6.1,pip-tools==6.8.0,platformdirs==2.2.0,pluggy==0.13.1,pre-commit==2.14.0,py==1.10.0,pyparsing==3.0.6,PyYAML==5.4.1,six==1.16.0,toml==0.10.2,tomli==1.2.1,toposort==1.6,tox==3.25.1,virtualenv==20.7.2
pre-commit run-test-pre: PYTHONHASHSEED='1889047509'
pre-commit run-test: commands[0] | pre-commit run --all-files
isort....................................................................Passed
mypy.....................................................................Failed
- hook id: mypy
- exit code: 1

superset/utils/pandas_postprocessing/utils.py:176: error: Argument 1 to "partial" has incompatible type "object"; expected "Callable[..., Any]"
superset/utils/pandas_postprocessing/flatten.py:88: error: Call to untyped function "is_sequence" in typed context
superset/utils/pandas_postprocessing/boxplot.py:60: error: No overload variant matches argument types "Any", "int", "str"
superset/utils/pandas_postprocessing/boxplot.py:60: note: Possible overload variants:
superset/utils/pandas_postprocessing/boxplot.py:60: note:     def (a: Union[_SupportsArray[dtype[Union[bool_, integer[Any], floating[Any]]]], _NestedSequence[_SupportsArray[dtype[Union[bool_, integer[Any], floating[Any]]]]], bool, int, float, _NestedSequence[Union[bool, int, float]]], q: Union[Union[Union[bool, bool_], int, integer[Any]], float, floating[Any]], axis: None = ..., out: None = ..., overwrite_input: bool = ..., method: Literal['inverted_cdf', 'averaged_inverted_cdf', 'closest_observation', 'interpolated_inverted_cdf', 'hazen', 'weibull', 'linear', 'median_unbiased', 'normal_unbiased', 'lower', 'higher', 'midpoint', 'nearest'] = ..., keepdims: Literal[False] = ...) -> floating[Any]
superset/utils/pandas_postprocessing/boxplot.py:60: note:     def (a: Union[_SupportsArray[dtype[Union[bool_, integer[Any], floating[Any], complexfloating[Any, Any]]]], _NestedSequence[_SupportsArray[dtype[Union[bool_, integer[Any], floating[Any], complexfloating[Any, Any]]]]], bool, int, float, complex, _NestedSequence[Union[bool, int, float, complex]]], q: Union[Union[Union[bool, bool_], int, integer[Any]], float, floating[Any]], axis: None = ..., out: None = ..., overwrite_input: bool = ..., method: Literal['inverted_cdf', 'averaged_inverted_cdf', 'closest_observation', 'interpolated_inverted_cdf', 'hazen', 'weibull', 'linear', 'median_unbiased', 'normal_unbiased', 'lower', 'higher', 'midpoint', 'nearest'] = ..., keepdims: Literal[False] = ...) -> complexfloating[Any, Any]
superset/utils/pandas_postprocessing/boxplot.py:60: note:     def (a: Union[_SupportsArray[dtype[Union[bool_, integer[Any], timedelta64]]], _NestedSequence[_SupportsArray[dtype[Union[bool_, integer[Any], timedelta64]]]], bool, int, _NestedSequence[Union[bool, int]]], q: Union[Union[Union[bool, bool_], int, integer[Any]], float, floating[Any]], axis: None = ..., out: None = ..., overwrite_input: bool = ..., method: Literal['inverted_cdf', 'averaged_inverted_cdf', 'closest_observation', 'interpolated_inverted_cdf', 'hazen', 'weibull', 'linear', 'median_unbiased', 'normal_unbiased', 'lower', 'higher', 'midpoint', 'nearest'] = ..., keepdims: Literal[False] = ...) -> timedelta64
superset/utils/pandas_postprocessing/boxplot.py:60: note:     def (a: Union[_SupportsArray[dtype[datetime64]], _NestedSequence[_SupportsArray[dtype[datetime64]]]], q: Union[Union[Union[bool, bool_], int, integer[Any]], float, floating[Any]], axis: None = ..., out: None = ..., overwrite_input: bool = ..., method: Literal['inverted_cdf', 'averaged_inverted_cdf', 'closest_observation', 'interpolated_inverted_cdf', 'hazen', 'weibull', 'linear', 'median_unbiased', 'normal_unbiased', 'lower', 'higher', 'midpoint', 'nearest'] = ..., keepdims: Literal[False] = ...) -> datetime64
superset/utils/pandas_postprocessing/boxplot.py:60: note:     def (a: Union[_SupportsArray[dtype[object_]], _NestedSequence[_SupportsArray[dtype[object_]]]], q: Union[Union[Union[bool, bool_], int, integer[Any]], float, floating[Any]], axis: None = ..., out: None = ..., overwrite_input: bool = ..., method: Literal['inverted_cdf', 'averaged_inverted_cdf', 'closest_observation', 'interpolated_inverted_cdf', 'hazen', 'weibull', 'linear', 'median_unbiased', 'normal_unbiased', 'lower', 'higher', 'midpoint', 'nearest'] = ..., keepdims: Literal[False] = ...) -> Any
superset/utils/pandas_postprocessing/boxplot.py:60: note:     def (a: Union[_SupportsArray[dtype[Union[bool_, integer[Any], floating[Any]]]], _NestedSequence[_SupportsArray[dtype[Union[bool_, integer[Any], floating[Any]]]]], bool, int, float, _NestedSequence[Union[bool, int, float]]], q: Union[_SupportsArray[dtype[Union[bool_, integer[Any], floating[Any]]]], _NestedSequence[_SupportsArray[dtype[Union[bool_, integer[Any], floating[Any]]]]], bool, int, float, _NestedSequence[Union[bool, int, float]]], axis: None = ..., out: None = ..., overwrite_input: bool = ..., method: Literal['inverted_cdf', 'averaged_inverted_cdf', 'closest_observation', 'interpolated_inverted_cdf', 'hazen', 'weibull', 'linear', 'median_unbiased', 'normal_unbiased', 'lower', 'higher', 'midpoint', 'nearest'] = ..., keepdims: Literal[False] = ...) -> ndarray[Any, dtype[floating[Any]]]
superset/utils/pandas_postprocessing/boxplot.py:60: note:     def (a: Union[_SupportsArray[dtype[Union[bool_, integer[Any], floating[Any], complexfloating[Any, Any]]]], _NestedSequence[_SupportsArray[dtype[Union[bool_, integer[Any], floating[Any], complexfloating[Any, Any]]]]], bool, int, float, complex, _NestedSequence[Union[bool, int, float, complex]]], q: Union[_SupportsArray[dtype[Union[bool_, integer[Any], floating[Any]]]], _NestedSequence[_SupportsArray[dtype[Union[bool_, integer[Any], floating[Any]]]]], bool, int, float, _NestedSequence[Union[bool, int, float]]], axis: None = ..., out: None = ..., overwrite_input: bool = ..., method: Literal['inverted_cdf', 'averaged_inverted_cdf', 'closest_observation', 'interpolated_inverted_cdf', 'hazen', 'weibull', 'linear', 'median_unbiased', 'normal_unbiased', 'lower', 'higher', 'midpoint', 'nearest'] = ..., keepdims: Literal[False] = ...) -> ndarray[Any, dtype[complexfloating[Any, Any]]]
superset/utils/pandas_postprocessing/boxplot.py:60: note:     def (a: Union[_SupportsArray[dtype[Union[bool_, integer[Any], timedelta64]]], _NestedSequence[_SupportsArray[dtype[Union[bool_, integer[Any], timedelta64]]]], bool, int, _NestedSequence[Union[bool, int]]], q: Union[_SupportsArray[dtype[Union[bool_, integer[Any], floating[Any]]]], _NestedSequence[_SupportsArray[dtype[Union[bool_, integer[Any], floating[Any]]]]], bool, int, float, _NestedSequence[Union[bool, int, float]]], axis: None = ..., out: None = ..., overwrite_input: bool = ..., method: Literal['inverted_cdf', 'averaged_inverted_cdf', 'closest_observation', 'interpolated_inverted_cdf', 'hazen', 'weibull', 'linear', 'median_unbiased', 'normal_unbiased', 'lower', 'higher', 'midpoint', 'nearest'] = ..., keepdims: Literal[False] = ...) -> ndarray[Any, dtype[timedelta64]]
superset/utils/pandas_postprocessing/boxplot.py:60: note:     def (a: Union[_SupportsArray[dtype[datetime64]], _NestedSequence[_SupportsArray[dtype[datetime64]]]], q: Union[_SupportsArray[dtype[Union[bool_, integer[Any], floating[Any]]]], _NestedSequence[_SupportsArray[dtype[Union[bool_, integer[Any], floating[Any]]]]], bool, int, float, _NestedSequence[Union[bool, int, float]]], axis: None = ..., out: None = ..., overwrite_input: bool = ..., method: Literal['inverted_cdf', 'averaged_inverted_cdf', 'closest_observation', 'interpolated_inverted_cdf', 'hazen', 'weibull', 'linear', 'median_unbiased', 'normal_unbiased', 'lower', 'higher', 'midpoint', 'nearest'] = ..., keepdims: Literal[False] = ...) -> ndarray[Any, dtype[datetime64]]
superset/utils/pandas_postprocessing/boxplot.py:60: note:     def (a: Union[_SupportsArray[dtype[object_]], _NestedSequence[_SupportsArray[dtype[object_]]]], q: Union[_SupportsArray[dtype[Union[bool_, integer[Any], floating[Any]]]], _NestedSequence[_SupportsArray[dtype[Union[bool_, integer[Any], floating[Any]]]]], bool, int, float, _NestedSequence[Union[bool, int, float]]], axis: None = ..., out: None = ..., overwrite_input: bool = ..., method: Literal['inverted_cdf', 'averaged_inverted_cdf', 'closest_observation', 'interpolated_inverted_cdf', 'hazen', 'weibull', 'linear', 'median_unbiased', 'normal_unbiased', 'lower', 'higher', 'midpoint', 'nearest'] = ..., keepdims: Literal[False] = ...) -> ndarray[Any, dtype[object_]]
superset/utils/pandas_postprocessing/boxplot.py:60: note:     def (a: Union[Union[_SupportsArray[dtype[Union[bool_, integer[Any], floating[Any], complexfloating[Any, Any]]]], _NestedSequence[_SupportsArray[dtype[Union[bool_, integer[Any], floating[Any], complexfloating[Any, Any]]]]], bool, int, float, complex, _NestedSequence[Union[bool, int, float, complex]]], Union[_SupportsArray[dtype[Union[bool_, integer[Any], timedelta64]]], _NestedSequence[_SupportsArray[dtype[Union[bool_, integer[Any], timedelta64]]]], bool, int, _NestedSequence[Union[bool, int]]], Union[_SupportsArray[dtype[Union[bool_, integer[Any], timedelta64]]], _NestedSequence[_SupportsArray[dtype[Union[bool_, integer[Any], timedelta64]]]], bool, int, _NestedSequence[Union[bool, int]]], Union[_SupportsArray[dtype[object_]], _NestedSequence[_SupportsArray[dtype[object_]]]]], q: Union[_SupportsArray[dtype[Union[bool_, integer[Any], floating[Any]]]], _NestedSequence[_SupportsArray[dtype[Union[bool_, integer[Any], floating[Any]]]]], bool, int, float, _NestedSequence[Union[bool, int, float]]], axis: Optional[Union[SupportsIndex, Sequence[SupportsIndex]]] = ..., out: None = ..., overwrite_input: bool = ..., method: Literal['inverted_cdf', 'averaged_inverted_cdf', 'closest_observation', 'interpolated_inverted_cdf', 'hazen', 'weibull', 'linear', 'median_unbiased', 'normal_unbiased', 'lower', 'higher', 'midpoint', 'nearest'] = ..., keepdims: bool = ...) -> Any
superset/utils/pandas_postprocessing/boxplot.py:60: note:     def [_ArrayType <: ndarray[Any, dtype[Any]]] (a: Union[Union[_SupportsArray[dtype[Union[bool_, integer[Any], floating[Any], complexfloating[Any, Any]]]], _NestedSequence[_SupportsArray[dtype[Union[bool_, integer[Any], floating[Any], complexfloating[Any, Any]]]]], bool, int, float, complex, _NestedSequence[Union[bool, int, float, complex]]], Union[_SupportsArray[dtype[Union[bool_, integer[Any], timedelta64]]], _NestedSequence[_SupportsArray[dtype[Union[bool_, integer[Any], timedelta64]]]], bool, int, _NestedSequence[Union[bool, int]]], Union[_SupportsArray[dtype[Union[bool_, integer[Any], timedelta64]]], _NestedSequence[_SupportsArray[dtype[Union[bool_, integer[Any], timedelta64]]]], bool, int, _NestedSequence[Union[bool, int]]], Union[_SupportsArray[dtype[object_]], _NestedSequence[_SupportsArray[dtype[object_]]]]], q: Union[_SupportsArray[dtype[Union[bool_, integer[Any], floating[Any]]]], _NestedSequence[_SupportsArray[dtype[Union[bool_, integer[Any], floating[Any]]]]], bool, int, float, _NestedSequence[Union[bool, int, float]]], axis: Optional[Union[SupportsIndex, Sequence[SupportsIndex]]] = ..., out: _ArrayType = ..., overwrite_input: bool = ..., method: Literal['inverted_cdf', 'averaged_inverted_cdf', 'closest_observation', 'interpolated_inverted_cdf', 'hazen', 'weibull', 'linear', 'median_unbiased', 'normal_unbiased', 'lower', 'higher', 'midpoint', 'nearest'] = ..., keepdims: bool = ...) -> _ArrayType
superset/utils/pandas_postprocessing/boxplot.py:63: error: No overload variant matches argument types "Any", "int", "str"
superset/utils/pandas_postprocessing/boxplot.py:63: note: Possible overload variants:
superset/utils/pandas_postprocessing/boxplot.py:63: note:     def (a: Union[_SupportsArray[dtype[Union[bool_, integer[Any], floating[Any]]]], _NestedSequence[_SupportsArray[dtype[Union[bool_, integer[Any], floating[Any]]]]], bool, int, float, _NestedSequence[Union[bool, int, float]]], q: Union[Union[Union[bool, bool_], int, integer[Any]], float, floating[Any]], axis: None = ..., out: None = ..., overwrite_input: bool = ..., method: Literal['inverted_cdf', 'averaged_inverted_cdf', 'closest_observation', 'interpolated_inverted_cdf', 'hazen', 'weibull', 'linear', 'median_unbiased', 'normal_unbiased', 'lower', 'higher', 'midpoint', 'nearest'] = ..., keepdims: Literal[False] = ...) -> floating[Any]
superset/utils/pandas_postprocessing/boxplot.py:63: note:     def (a: Union[_SupportsArray[dtype[Union[bool_, integer[Any], floating[Any], complexfloating[Any, Any]]]], _NestedSequence[_SupportsArray[dtype[Union[bool_, integer[Any], floating[Any], complexfloating[Any, Any]]]]], bool, int, float, complex, _NestedSequence[Union[bool, int, float, complex]]], q: Union[Union[Union[bool, bool_], int, integer[Any]], float, floating[Any]], axis: None = ..., out: None = ..., overwrite_input: bool = ..., method: Literal['inverted_cdf', 'averaged_inverted_cdf', 'closest_observation', 'interpolated_inverted_cdf', 'hazen', 'weibull', 'linear', 'median_unbiased', 'normal_unbiased', 'lower', 'higher', 'midpoint', 'nearest'] = ..., keepdims: Literal[False] = ...) -> complexfloating[Any, Any]
superset/utils/pandas_postprocessing/boxplot.py:63: note:     def (a: Union[_SupportsArray[dtype[Union[bool_, integer[Any], timedelta64]]], _NestedSequence[_SupportsArray[dtype[Union[bool_, integer[Any], timedelta64]]]], bool, int, _NestedSequence[Union[bool, int]]], q: Union[Union[Union[bool, bool_], int, integer[Any]], float, floating[Any]], axis: None = ..., out: None = ..., overwrite_input: bool = ..., method: Literal['inverted_cdf', 'averaged_inverted_cdf', 'closest_observation', 'interpolated_inverted_cdf', 'hazen', 'weibull', 'linear', 'median_unbiased', 'normal_unbiased', 'lower', 'higher', 'midpoint', 'nearest'] = ..., keepdims: Literal[False] = ...) -> timedelta64
superset/utils/pandas_postprocessing/boxplot.py:63: note:     def (a: Union[_SupportsArray[dtype[datetime64]], _NestedSequence[_SupportsArray[dtype[datetime64]]]], q: Union[Union[Union[bool, bool_], int, integer[Any]], float, floating[Any]], axis: None = ..., out: None = ..., overwrite_input: bool = ..., method: Literal['inverted_cdf', 'averaged_inverted_cdf', 'closest_observation', 'interpolated_inverted_cdf', 'hazen', 'weibull', 'linear', 'median_unbiased', 'normal_unbiased', 'lower', 'higher', 'midpoint', 'nearest'] = ..., keepdims: Literal[False] = ...) -> datetime64
superset/utils/pandas_postprocessing/boxplot.py:63: note:     def (a: Union[_SupportsArray[dtype[object_]], _NestedSequence[_SupportsArray[dtype[object_]]]], q: Union[Union[Union[bool, bool_], int, integer[Any]], float, floating[Any]], axis: None = ..., out: None = ..., overwrite_input: bool = ..., method: Literal['inverted_cdf', 'averaged_inverted_cdf', 'closest_observation', 'interpolated_inverted_cdf', 'hazen', 'weibull', 'linear', 'median_unbiased', 'normal_unbiased', 'lower', 'higher', 'midpoint', 'nearest'] = ..., keepdims: Literal[False] = ...) -> Any
superset/utils/pandas_postprocessing/boxplot.py:63: note:     def (a: Union[_SupportsArray[dtype[Union[bool_, integer[Any], floating[Any]]]], _NestedSequence[_SupportsArray[dtype[Union[bool_, integer[Any], floating[Any]]]]], bool, int, float, _NestedSequence[Union[bool, int, float]]], q: Union[_SupportsArray[dtype[Union[bool_, integer[Any], floating[Any]]]], _NestedSequence[_SupportsArray[dtype[Union[bool_, integer[Any], floating[Any]]]]], bool, int, float, _NestedSequence[Union[bool, int, float]]], axis: None = ..., out: None = ..., overwrite_input: bool = ..., method: Literal['inverted_cdf', 'averaged_inverted_cdf', 'closest_observation', 'interpolated_inverted_cdf', 'hazen', 'weibull', 'linear', 'median_unbiased', 'normal_unbiased', 'lower', 'higher', 'midpoint', 'nearest'] = ..., keepdims: Literal[False] = ...) -> ndarray[Any, dtype[floating[Any]]]
superset/utils/pandas_postprocessing/boxplot.py:63: note:     def (a: Union[_SupportsArray[dtype[Union[bool_, integer[Any], floating[Any], complexfloating[Any, Any]]]], _NestedSequence[_SupportsArray[dtype[Union[bool_, integer[Any], floating[Any], complexfloating[Any, Any]]]]], bool, int, float, complex, _NestedSequence[Union[bool, int, float, complex]]], q: Union[_SupportsArray[dtype[Union[bool_, integer[Any], floating[Any]]]], _NestedSequence[_SupportsArray[dtype[Union[bool_, integer[Any], floating[Any]]]]], bool, int, float, _NestedSequence[Union[bool, int, float]]], axis: None = ..., out: None = ..., overwrite_input: bool = ..., method: Literal['inverted_cdf', 'averaged_inverted_cdf', 'closest_observation', 'interpolated_inverted_cdf', 'hazen', 'weibull', 'linear', 'median_unbiased', 'normal_unbiased', 'lower', 'higher', 'midpoint', 'nearest'] = ..., keepdims: Literal[False] = ...) -> ndarray[Any, dtype[complexfloating[Any, Any]]]
superset/utils/pandas_postprocessing/boxplot.py:63: note:     def (a: Union[_SupportsArray[dtype[Union[bool_, integer[Any], timedelta64]]], _NestedSequence[_SupportsArray[dtype[Union[bool_, integer[Any], timedelta64]]]], bool, int, _NestedSequence[Union[bool, int]]], q: Union[_SupportsArray[dtype[Union[bool_, integer[Any], floating[Any]]]], _NestedSequence[_SupportsArray[dtype[Union[bool_, integer[Any], floating[Any]]]]], bool, int, float, _NestedSequence[Union[bool, int, float]]], axis: None = ..., out: None = ..., overwrite_input: bool = ..., method: Literal['inverted_cdf', 'averaged_inverted_cdf', 'closest_observation', 'interpolated_inverted_cdf', 'hazen', 'weibull', 'linear', 'median_unbiased', 'normal_unbiased', 'lower', 'higher', 'midpoint', 'nearest'] = ..., keepdims: Literal[False] = ...) -> ndarray[Any, dtype[timedelta64]]
superset/utils/pandas_postprocessing/boxplot.py:63: note:     def (a: Union[_SupportsArray[dtype[datetime64]], _NestedSequence[_SupportsArray[dtype[datetime64]]]], q: Union[_SupportsArray[dtype[Union[bool_, integer[Any], floating[Any]]]], _NestedSequence[_SupportsArray[dtype[Union[bool_, integer[Any], floating[Any]]]]], bool, int, float, _NestedSequence[Union[bool, int, float]]], axis: None = ..., out: None = ..., overwrite_input: bool = ..., method: Literal['inverted_cdf', 'averaged_inverted_cdf', 'closest_observation', 'interpolated_inverted_cdf', 'hazen', 'weibull', 'linear', 'median_unbiased', 'normal_unbiased', 'lower', 'higher', 'midpoint', 'nearest'] = ..., keepdims: Literal[False] = ...) -> ndarray[Any, dtype[datetime64]]
superset/utils/pandas_postprocessing/boxplot.py:63: note:     def (a: Union[_SupportsArray[dtype[object_]], _NestedSequence[_SupportsArray[dtype[object_]]]], q: Union[_SupportsArray[dtype[Union[bool_, integer[Any], floating[Any]]]], _NestedSequence[_SupportsArray[dtype[Union[bool_, integer[Any], floating[Any]]]]], bool, int, float, _NestedSequence[Union[bool, int, float]]], axis: None = ..., out: None = ..., overwrite_input: bool = ..., method: Literal['inverted_cdf', 'averaged_inverted_cdf', 'closest_observation', 'interpolated_inverted_cdf', 'hazen', 'weibull', 'linear', 'median_unbiased', 'normal_unbiased', 'lower', 'higher', 'midpoint', 'nearest'] = ..., keepdims: Literal[False] = ...) -> ndarray[Any, dtype[object_]]
superset/utils/pandas_postprocessing/boxplot.py:63: note:     def (a: Union[Union[_SupportsArray[dtype[Union[bool_, integer[Any], floating[Any], complexfloating[Any, Any]]]], _NestedSequence[_SupportsArray[dtype[Union[bool_, integer[Any], floating[Any], complexfloating[Any, Any]]]]], bool, int, float, complex, _NestedSequence[Union[bool, int, float, complex]]], Union[_SupportsArray[dtype[Union[bool_, integer[Any], timedelta64]]], _NestedSequence[_SupportsArray[dtype[Union[bool_, integer[Any], timedelta64]]]], bool, int, _NestedSequence[Union[bool, int]]], Union[_SupportsArray[dtype[Union[bool_, integer[Any], timedelta64]]], _NestedSequence[_SupportsArray[dtype[Union[bool_, integer[Any], timedelta64]]]], bool, int, _NestedSequence[Union[bool, int]]], Union[_SupportsArray[dtype[object_]], _NestedSequence[_SupportsArray[dtype[object_]]]]], q: Union[_SupportsArray[dtype[Union[bool_, integer[Any], floating[Any]]]], _NestedSequence[_SupportsArray[dtype[Union[bool_, integer[Any], floating[Any]]]]], bool, int, float, _NestedSequence[Union[bool, int, float]]], axis: Optional[Union[SupportsIndex, Sequence[SupportsIndex]]] = ..., out: None = ..., overwrite_input: bool = ..., method: Literal['inverted_cdf', 'averaged_inverted_cdf', 'closest_observation', 'interpolated_inverted_cdf', 'hazen', 'weibull', 'linear', 'median_unbiased', 'normal_unbiased', 'lower', 'higher', 'midpoint', 'nearest'] = ..., keepdims: bool = ...) -> Any
superset/utils/pandas_postprocessing/boxplot.py:63: note:     def [_ArrayType <: ndarray[Any, dtype[Any]]] (a: Union[Union[_SupportsArray[dtype[Union[bool_, integer[Any], floating[Any], complexfloating[Any, Any]]]], _NestedSequence[_SupportsArray[dtype[Union[bool_, integer[Any], floating[Any], complexfloating[Any, Any]]]]], bool, int, float, complex, _NestedSequence[Union[bool, int, float, complex]]], Union[_SupportsArray[dtype[Union[bool_, integer[Any], timedelta64]]], _NestedSequence[_SupportsArray[dtype[Union[bool_, integer[Any], timedelta64]]]], bool, int, _NestedSequence[Union[bool, int]]], Union[_SupportsArray[dtype[Union[bool_, integer[Any], timedelta64]]], _NestedSequence[_SupportsArray[dtype[Union[bool_, integer[Any], timedelta64]]]], bool, int, _NestedSequence[Union[bool, int]]], Union[_SupportsArray[dtype[object_]], _NestedSequence[_SupportsArray[dtype[object_]]]]], q: Union[_SupportsArray[dtype[Union[bool_, integer[Any], floating[Any]]]], _NestedSequence[_SupportsArray[dtype[Union[bool_, integer[Any], floating[Any]]]]], bool, int, float, _NestedSequence[Union[bool, int, float]]], axis: Optional[Union[SupportsIndex, Sequence[SupportsIndex]]] = ..., out: _ArrayType = ..., overwrite_input: bool = ..., method: Literal['inverted_cdf', 'averaged_inverted_cdf', 'closest_observation', 'interpolated_inverted_cdf', 'hazen', 'weibull', 'linear', 'median_unbiased', 'normal_unbiased', 'lower', 'higher', 'midpoint', 'nearest'] = ..., keepdims: bool = ...) -> _ArrayType
superset/utils/pandas_postprocessing/boxplot.py:102: error: Incompatible types in assignment (expression has type overloaded function, variable has type "Callable[[Any], float]")
superset/utils/pandas_postprocessing/boxplot.py:103: error: Incompatible types in assignment (expression has type overloaded function, variable has type "Callable[[Any], float]")
superset/utils/pandas_postprocessing/boxplot.py:129: error: Module has no attribute "object"; maybe "object_"?
superset/result_set.py:65: error: Missing type parameters for generic type "ndarray"
superset/result_set.py:68: error: List item 0 has incompatible type "str"; expected "Sequence[Literal['aligned', 'allocate', 'arraymask', 'copy', 'config', 'nbo', 'no_subtype', 'no_broadcast', 'overlap_assume_elementwise', 'readonly', 'readwrite', 'updateifcopy', 'virtual', 'writeonly', 'writemasked']]"
superset/result_set.py:72: error: Unsupported target for indexed assignment ("Tuple[ndarray[Any, dtype[Any]], ...]")
superset/result_set.py:74: error: Unsupported target for indexed assignment ("Tuple[ndarray[Any, dtype[Any]], ...]")
superset/result_set.py:109: error: Missing type parameters for generic type "ndarray"
superset/result_set.py:159: error: Argument 1 to "first_nonempty" of "SupersetResultSet" has incompatible type "ndarray[Any, dtype[Any]]"; expected "List[Any]"
superset/reports/commands/alert.py:87: error: Missing type parameters for generic type "recarray"
superset/reports/commands/alert.py:92: error: Missing type parameters for generic type "recarray"
superset/reports/commands/alert.py:111: error: Missing type parameters for generic type "recarray"
superset/db_engine_specs/hive.py:209: error: Missing type parameters for generic type "dtype"
Found 17 errors in 6 files (checked 1223 source files)

pip-compile-multi verify.................................................Passed
Check docstring is first.................................................Passed
Check for added large files..............................................Passed
Check Yaml...............................................................Passed
Debug Statements (Python)................................................Passed
Fix End of Files.........................................................Passed
Trim Trailing Whitespace.................................................Passed
black....................................................................Passed
Blacklist................................................................Passed
```

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
